### PR TITLE
Navball heading indicator

### DIFF
--- a/web/src/lib/components/Dashboard/RocketNavBall/HeadingCompass/HeadingCompass.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/HeadingCompass/HeadingCompass.svelte
@@ -93,7 +93,7 @@
 	class="w-full h-full flex-col text-center select-none"
 >
 	<svg
-		class="absolute top-0 left-0 w-full h-full"
+		class="w-full h-full"
 		transform="rotate({-90 - heading * RAD2DEG})"
 		width={w}
 		height={h}
@@ -127,7 +127,14 @@
 		height={h}
 		xmlns="http://www.w3.org/2000/svg"
 	>
-		<line x1={w / 2} y1={h / 2} x2={w / 2} y2={h / 2 - radius} stroke="red" stroke-width="2" />
+		<line
+			x1={w / 2}
+			y1={h / 2 - radius * 0.9}
+			x2={w / 2}
+			y2={h / 2 - radius}
+			stroke="red"
+			stroke-width="2"
+		/>
 		<!-- Text -->
 		<rect
 			x={w / 2 - 50}
@@ -153,7 +160,6 @@
 	</svg>
 </div>
 
-<!-- Animate rotatio -->
 <style>
 	svg {
 		transition: transform 0.25s;

--- a/web/src/lib/components/Dashboard/RocketNavBall/HeadingCompass/HeadingCompass.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/HeadingCompass/HeadingCompass.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
+	import { backInOut, cubicInOut, elasticIn, elasticInOut } from 'svelte/easing';
+	import { tweened } from 'svelte/motion';
 	import { RAD2DEG } from 'three/src/math/MathUtils.js';
 
 	let w = 100;
 	let h = 100;
 
 	export let heading = 0;
+
+	let headingTweened = tweened(0, {
+		duration: 250,
+		easing: cubicInOut
+	});
+
+	$: headingTweened.set(heading);
 
 	const breaksPoints = {
 		0: 'N',
@@ -94,7 +103,7 @@
 >
 	<svg
 		class="w-full h-full"
-		transform="rotate({-90 - heading * RAD2DEG})"
+		transform="rotate({-90 - $headingTweened * RAD2DEG})"
 		width={w}
 		height={h}
 		xmlns="http://www.w3.org/2000/svg"
@@ -155,7 +164,7 @@
 			alignment-baseline="middle"
 			font-size="24"
 		>
-			{(heading * RAD2DEG).toFixed(2)}°
+			{($headingTweened * RAD2DEG).toFixed(2)}°
 		</text>
 	</svg>
 </div>

--- a/web/src/lib/components/Dashboard/RocketNavBall/HeadingCompass/HeadingCompass.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/HeadingCompass/HeadingCompass.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+	import { RAD2DEG } from 'three/src/math/MathUtils.js';
+
+	let w = 100;
+	let h = 100;
+
+	export let heading = 0;
+
+	const breaksPoints = {
+		0: 'N',
+		45: 'NE',
+		90: 'E',
+		135: 'SE',
+		180: 'S',
+		225: 'SW',
+		270: 'W',
+		315: 'NW'
+	} as const;
+
+	let angle = 0;
+	$: radius = Math.min(w, h - 80) / 2;
+
+	type Lines = {
+		x: number;
+		y: number;
+		x2: number;
+		y2: number;
+	};
+
+	type Texts = {
+		x: number;
+		y: number;
+		text: string;
+		r: number;
+		color?: string;
+	};
+
+	let lines: Lines[] = [];
+	let texts: Texts[] = [];
+
+	$: {
+		lines = [];
+		texts = [];
+		angle = 0;
+		while (angle < 360) {
+			const center_x = w / 2;
+			const center_y = h / 2;
+
+			const x = center_x + Math.cos((angle * Math.PI) / 180) * radius;
+			const y = center_y + Math.sin((angle * Math.PI) / 180) * radius;
+
+			let lineDist = 0.05;
+			if (angle % 10 === 0) {
+				lineDist = 0.1;
+			}
+			if (angle % 30 === 0) {
+				lineDist = 0.1;
+
+				// Add text if not a label
+				if (breaksPoints[angle as keyof typeof breaksPoints] === undefined) {
+					const text = angle;
+					const textDist = 0.15;
+					const x = center_x + Math.cos((angle * Math.PI) / 180) * radius * (1 - textDist);
+					const y = center_y + Math.sin((angle * Math.PI) / 180) * radius * (1 - textDist);
+					const rad = angle + 90;
+					texts.push({ x, y, text: text.toString(), r: rad });
+				}
+			}
+			if (angle % 45 === 0) {
+				lineDist = 0.2;
+			}
+
+			const text = breaksPoints[angle as keyof typeof breaksPoints];
+			if (text) {
+				const x = center_x + Math.cos((angle * Math.PI) / 180) * radius * 0.75;
+				const y = center_y + Math.sin((angle * Math.PI) / 180) * radius * 0.75;
+				const rad = angle + 90;
+				texts.push({ x, y, text, r: rad, color: 'red' });
+			}
+
+			const x2 = center_x + Math.cos((angle * Math.PI) / 180) * radius * (1 - lineDist);
+			const y2 = center_y + Math.sin((angle * Math.PI) / 180) * radius * (1 - lineDist);
+
+			lines.push({ x, y, x2, y2 });
+			angle += 5;
+		}
+	}
+</script>
+
+<div
+	bind:clientHeight={h}
+	bind:clientWidth={w}
+	class="w-full h-full flex-col text-center select-none"
+>
+	<svg
+		class="absolute top-0 left-0 w-full h-full"
+		transform="rotate({-90 - heading * RAD2DEG})"
+		width={w}
+		height={h}
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<circle cx={w / 2} cy={h / 2} r={radius} stroke="white" stroke-width="2" fill="none" />
+
+		{#each lines as line}
+			<line x1={line.x} y1={line.y} x2={line.x2} y2={line.y2} stroke="white" />
+		{/each}
+
+		{#each texts as text}
+			<text
+				x={text.x}
+				y={text.y}
+				fill={text.color ?? 'white'}
+				transform={`rotate(${text.r} ${text.x} ${text.y})`}
+				text-anchor="middle"
+				alignment-baseline="middle"
+				font-size="24"
+			>
+				{text.text}
+			</text>
+		{/each}
+	</svg>
+
+	<!-- SVG for the compass needle -->
+	<svg
+		class="absolute top-0 left-0 w-full h-full"
+		width={w}
+		height={h}
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<line x1={w / 2} y1={h / 2} x2={w / 2} y2={h / 2 - radius} stroke="red" stroke-width="2" />
+		<!-- Text -->
+		<rect
+			x={w / 2 - 50}
+			y={h / 2 - radius - 20}
+			width={100}
+			height={40}
+			fill="white"
+			stroke-width="2"
+			rx="5"
+			ry="5"
+		/>
+
+		<text
+			x={w / 2}
+			y={h / 2 - radius}
+			fill="black"
+			text-anchor="middle"
+			alignment-baseline="middle"
+			font-size="24"
+		>
+			{(heading * RAD2DEG).toFixed(2)}°
+		</text>
+	</svg>
+</div>
+
+<!-- Animate rotatio -->
+<style>
+	svg {
+		transition: transform 0.25s;
+	}
+</style>

--- a/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBall.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBall.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Canvas } from '@threlte/core';
+	import { Environment } from '@threlte/extras';
 	import { Quaternion } from 'three/src/Three.js';
 	import NavBallScene from './NavBallScene.svelte';
 	export let targetRotation: Quaternion = new Quaternion();
@@ -11,11 +12,11 @@
 
 <div bind:clientHeight={h} bind:clientWidth={w} class="grid place-items-center w-full h-full">
 	<div
-		class="navball-wrapper"
+		class="navball-wrapper relative"
 		style="
-		width: {squareSize}px;
-		height: {squareSize}px;
-	"
+	width: {squareSize}px;
+	height: {squareSize}px;
+"
 	>
 		<Canvas
 			size={{
@@ -23,6 +24,8 @@
 				width: 500
 			}}
 		>
+			<Environment path={'/textures/cubemap/'} files={'road.hdr'} isBackground={true} />
+
 			<NavBallScene bind:targetRotation />
 		</Canvas>
 	</div>

--- a/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBall.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBall.svelte
@@ -1,16 +1,42 @@
 <script lang="ts">
 	import { Canvas } from '@threlte/core';
-	import { Environment } from '@threlte/extras';
 	import { Quaternion } from 'three/src/Three.js';
 	import NavBallScene from './NavBallScene.svelte';
 	export let targetRotation: Quaternion = new Quaternion();
 
-	export let useRocketModel = false;
+	let w = 500;
+	let h = 500;
+	$: squareSize = Math.min(w - 200, h - 300);
 </script>
 
-<div class="flex-1 w-full h-full">
-	<Canvas>
-		<Environment path={'/textures/cubemap/'} files={'road.hdr'} isBackground={true} />
-		<NavBallScene bind:targetRotation bind:useRocketModel />
-	</Canvas>
+<div bind:clientHeight={h} bind:clientWidth={w} class="grid place-items-center w-full h-full">
+	<div
+		class="navball-wrapper"
+		style="
+		width: {squareSize}px;
+		height: {squareSize}px;
+	"
+	>
+		<Canvas
+			size={{
+				height: 500,
+				width: 500
+			}}
+		>
+			<NavBallScene bind:targetRotation />
+		</Canvas>
+	</div>
 </div>
+
+<style>
+	:global(.navball-wrapper canvas) {
+		min-width: 100%;
+		min-height: 100%;
+		max-width: 100%;
+		max-height: 100%;
+	}
+
+	/* navball wrapper is an auto sized square inside the grid */
+	.navball-wrapper {
+	}
+</style>

--- a/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBall.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBall.svelte
@@ -6,7 +6,7 @@
 
 	let w = 500;
 	let h = 500;
-	$: squareSize = Math.min(w - 200, h - 300);
+	$: squareSize = Math.min(w - 80, h - 160);
 </script>
 
 <div bind:clientHeight={h} bind:clientWidth={w} class="grid place-items-center w-full h-full">

--- a/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBall.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBall.svelte
@@ -35,8 +35,4 @@
 		max-width: 100%;
 		max-height: 100%;
 	}
-
-	/* navball wrapper is an auto sized square inside the grid */
-	.navball-wrapper {
-	}
 </style>

--- a/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBallScene.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBallScene.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { T } from '@threlte/core';
-	import { useTexture } from '@threlte/extras';
-	import { Quaternion } from 'three';
+	import { Billboard, MeshLineGeometry, MeshLineMaterial, useTexture } from '@threlte/extras';
+	import { Quaternion, Vector3 } from 'three';
 	import navballfrag from './NavBallShader/fragment.glsl?raw';
 	import navballvert from './NavBallShader/vertex.glsl?raw';
 
@@ -22,7 +22,33 @@
 	});
 </script>
 
-<T.OrthographicCamera makeDefault={true} position={[0, 0, 10]} zoom={200} />
+<T.OrthographicCamera makeDefault={true} position={[0, 0, 20]} zoom={200} />
+
+<Billboard position={[0, 0, 2]}>
+	<T.Mesh>
+		<T.SphereGeometry args={[0.02]} />
+		<T.MeshBasicMaterial color="orange" />
+	</T.Mesh>
+
+	<T.Mesh>
+		<MeshLineGeometry
+			points={[
+				new Vector3(0, 0.5),
+				new Vector3(0.25, 0.5),
+				new Vector3(0.5, 0.25),
+				new Vector3(0.75, 0.5),
+				new Vector3(1, 0.5)
+			].map((v) => {
+				v.x *= 0.5;
+				v.y *= 0.5;
+				v.x -= 0.25;
+				v.y -= 0.25;
+				return v;
+			})}
+		/>
+		<MeshLineMaterial width={0.015} color="orange" />
+	</T.Mesh>
+</Billboard>
 
 {#await map then tex}
 	<T.Mesh quaternion={[displayRotation.x, displayRotation.y, displayRotation.z, displayRotation.w]}>

--- a/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBallScene.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBallScene.svelte
@@ -40,7 +40,7 @@
 	}
 </script>
 
-<T.OrthographicCamera makeDefault={true} position={[0, 0, 10]} zoom={250} />
+<T.OrthographicCamera makeDefault={true} position={[0, 0, 10]} zoom={200} />
 
 {#await map then tex}
 	<T.Mesh bind:rotation={rot}>

--- a/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBallScene.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBallScene.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
 	import { T } from '@threlte/core';
-	import { OrbitControls, useTexture } from '@threlte/extras';
+	import { useTexture } from '@threlte/extras';
 	import { tweened, type Tweened } from 'svelte/motion';
 	import { Euler, Quaternion, type EulerOrder } from 'three';
-	import Lazy from '../../../Common/Lazy.svelte';
+	import navballfrag from './NavBallShader/fragment.glsl?raw';
+	import navballvert from './NavBallShader/vertex.glsl?raw';
+
 	const map = useTexture('textures/navball.png');
 	map.then((tex) => {
 		tex.anisotropy = 32;
+		tex.colorSpace = 'srgb-linear';
 	});
 
-	export let useRocketModel = false;
 	export let targetRotation: Quaternion = new Quaternion();
 
 	let tweenedRotation: Tweened<Quaternion> = tweened(targetRotation, {
@@ -38,37 +40,17 @@
 	}
 </script>
 
-<T.PerspectiveCamera
-	makeDefault
-	fov={60}
-	position={[0, 35, 0]}
-	near={0.1}
-	far={1000}
-	aspect={1}
-	on:create={({ ref }) => {
-		ref.lookAt(0, 1, 0);
-	}}
->
-	<OrbitControls enableDamping />
-</T.PerspectiveCamera>
+<T.OrthographicCamera makeDefault={true} position={[0, 0, 10]} zoom={250} />
 
-<T.PolarGridHelper args={[15, 15, 8, 64]} />
-
-{#if useRocketModel}
-	<Lazy
-		this={async () => (await import('$lib/components/models/Rocket.svelte')).default}
-		rotation={rot}
-		scale={0.75}
-	></Lazy>
-{:else}
-	{#await map then tex}
-		<T.Mesh bind:rotation={rot}>
-			<T.SphereGeometry args={[10, 64, 32]} />
-			<T.MeshStandardMaterial map={tex} />
-		</T.Mesh>
-		<T.Mesh position.y="10">
-			<T.SphereGeometry args={[0.3, 10, 2]} />
-			<T.MeshStandardMaterial color={[1, 0, 1]} />
-		</T.Mesh>
-	{/await}
-{/if}
+{#await map then tex}
+	<T.Mesh bind:rotation={rot}>
+		<T.SphereGeometry />
+		<T.ShaderMaterial
+			fragmentShader={navballfrag}
+			vertexShader={navballvert}
+			uniforms={{
+				uTexture: { value: tex }
+			}}
+		/>
+	</T.Mesh>
+{/await}

--- a/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBallShader/fragment.glsl
+++ b/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBallShader/fragment.glsl
@@ -1,0 +1,20 @@
+uniform sampler2D uTexture;
+
+varying vec2 vUv;
+varying vec3 vNormal;
+varying vec3 vViewPosition;
+
+void main() {
+    vec3 viewDirection = normalize(-vViewPosition);
+
+    float fresnelEffect = pow(1.0 - dot(viewDirection, normalize(vNormal)), 2.0);
+    fresnelEffect = clamp(fresnelEffect, 0.0, 1.0);
+
+
+    vec4 textureColor = texture2D(uTexture, vUv) ;
+    vec4 edgeColor = vec4(0.0, 0.0, 0.0, 1.0); 
+
+    vec4 finalColor = mix(textureColor, edgeColor, fresnelEffect);
+
+    gl_FragColor = finalColor;
+}

--- a/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBallShader/vertex.glsl
+++ b/web/src/lib/components/Dashboard/RocketNavBall/NavBall/NavBallShader/vertex.glsl
@@ -1,0 +1,11 @@
+varying vec2 vUv;
+varying vec3 vNormal;
+varying vec3 vViewPosition;
+
+void main() {
+    vUv = uv;
+    vNormal = normalize(normalMatrix * normal);
+    vec4 pos = modelViewMatrix * vec4(position, 1.0);
+    vViewPosition = pos.xyz;
+    gl_Position = projectionMatrix * pos;
+}

--- a/web/src/lib/components/Dashboard/RocketNavBall/RocketNavBall.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/RocketNavBall.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	// import { quat } from '$lib/realtime/sensors';
-	import Timeline from '$lib/components/Common/Timeline/Timeline.svelte';
 	import { tweened } from 'svelte/motion';
 	import { Euler, MathUtils, Matrix4, Quaternion, Vector3, type EulerOrder } from 'three';
 	import HeadingCompass from './HeadingCompass/HeadingCompass.svelte';
@@ -80,10 +79,6 @@
 	<span class="text-right">{MathUtils.radToDeg(eulerRepr.z ?? 0).toFixed(2)}°</span>
 	<span>Pointing</span>
 	<span class="text-right">{upright(latestReportedRotation) ? 'Up' : 'Down'}</span>
-</div>
-
-<div class="z-10 absolute bottom-0 left-0 right-0 variant-glass h-12 text-dark-token">
-	<Timeline></Timeline>
 </div>
 
 <div class="absolute bg-black h-full w-full"></div>

--- a/web/src/lib/components/Dashboard/RocketNavBall/RocketNavBall.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/RocketNavBall.svelte
@@ -30,8 +30,7 @@
 	$: upTransformed = new Vector3(0, 1, 0).applyQuaternion(latestReportedRotation);
 	$: pitch = MathUtils.radToDeg(Math.asin(upTransformed.y));
 
-	$: heading =
-		(MathUtils.radToDeg(Math.atan2(upTransformed.x, upTransformed.z)) + 360 + 180 + 90) % 360;
+	$: heading = (MathUtils.radToDeg(Math.atan2(upTransformed.x, upTransformed.z)) + 360 + 90) % 360;
 
 	$: transformed = new Vector3(0, 0, -1).applyQuaternion(latestReportedRotation);
 	$: roll = MathUtils.radToDeg(Math.atan2(transformed.x, transformed.z) + Math.PI);

--- a/web/src/lib/components/Dashboard/RocketNavBall/RocketNavBall.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/RocketNavBall.svelte
@@ -71,7 +71,7 @@
 	}
 </script>
 
-<div class="z-10 absolute top-2 left-2 variant-glass p-2 grid grid-cols-2">
+<div class="z-10 absolute top-2 left-2 variant-glass p-2 grid grid-cols-2 text-dark-token">
 	<span>Roll</span>
 	<span class="text-right">{MathUtils.radToDeg(eulerRepr.x ?? 0).toFixed(2)}°</span>
 	<span>Pitch</span>
@@ -82,16 +82,16 @@
 	<span class="text-right">{upright(latestReportedRotation) ? 'Up' : 'Down'}</span>
 </div>
 
-<div class="z-10 absolute bottom-0 left-0 right-0 variant-glass h-12">
+<div class="z-10 absolute bottom-0 left-0 right-0 variant-glass h-12 text-dark-token">
 	<Timeline></Timeline>
 </div>
 
 <div class="absolute bg-black h-full w-full"></div>
 
-<div class="z-0 absolute inset-0">
-	<NavBall targetRotation={$targetRotation} />
-</div>
-
 <div class="z-0 absolute h-full w-full">
 	<HeadingCompass heading={$RocketCourse.data?.rocket_sensor_gps_vel[0]?.course ?? 0} />
+</div>
+
+<div class="z-0 absolute inset-0">
+	<NavBall targetRotation={$targetRotation} />
 </div>

--- a/web/src/lib/components/Dashboard/RocketNavBall/RocketNavBall.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/RocketNavBall.svelte
@@ -83,10 +83,9 @@
 
 <div class="absolute bg-black h-full w-full"></div>
 
-<div class="z-0 absolute h-full w-full">
-	<HeadingCompass heading={$RocketCourse.data?.rocket_sensor_gps_vel[0]?.course ?? 0} />
-</div>
-
 <div class="z-0 absolute inset-0">
 	<NavBall targetRotation={$targetRotation} />
+</div>
+<div class="z-0 absolute h-full w-full">
+	<HeadingCompass heading={$RocketCourse.data?.rocket_sensor_gps_vel[0]?.course ?? 0} />
 </div>

--- a/web/src/lib/components/Dashboard/RocketNavBall/RocketNavBall.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/RocketNavBall.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { MathUtils, Quaternion, Vector3 } from 'three';
+	import { DEG2RAD } from 'three/src/math/MathUtils.js';
 	import HeadingCompass from './HeadingCompass/HeadingCompass.svelte';
 	import NavBall from './NavBall/NavBall.svelte';
 	import { RocketQuat } from './types';
@@ -54,6 +55,6 @@
 	<NavBall targetRotation={latestReportedRotation} />
 </div>
 
-<div class="z-0 absolute h-full w-full">
-	<HeadingCompass {heading} />
+<div class="z-0 absolute h-full w-full pointer-events-none">
+	<HeadingCompass heading={heading * DEG2RAD} />
 </div>

--- a/web/src/lib/components/Dashboard/RocketNavBall/RocketNavBall.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/RocketNavBall.svelte
@@ -41,8 +41,6 @@
 	<span class="text-right">{roll.toFixed(2)}°</span>
 	<span>Pitch</span>
 	<span class="text-right">{pitch.toFixed(2)}°</span>
-	<span>Heading</span>
-	<span class="text-right">{heading.toFixed(2)}°</span>
 
 	<span>Pointing</span>
 	<span class="text-right">{pitch > 0 ? 'Up' : 'Down'}</span>

--- a/web/src/lib/components/Dashboard/RocketNavBall/RocketNavBall.svelte
+++ b/web/src/lib/components/Dashboard/RocketNavBall/RocketNavBall.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
 	// import { quat } from '$lib/realtime/sensors';
-	import { SlideToggle } from '@skeletonlabs/skeleton';
+	import Timeline from '$lib/components/Common/Timeline/Timeline.svelte';
 	import { tweened } from 'svelte/motion';
 	import { Euler, MathUtils, Matrix4, Quaternion, Vector3, type EulerOrder } from 'three';
+	import HeadingCompass from './HeadingCompass/HeadingCompass.svelte';
 	import NavBall from './NavBall/NavBall.svelte';
-	import { RocketQuat } from './types';
-	import Timeline from '$lib/components/Common/Timeline/Timeline.svelte';
+	import { RocketCourse, RocketQuat } from './types';
 
 	let ninetyDegVerticalRot = new Quaternion();
-	let useRocketModel = false;
 
 	ninetyDegVerticalRot.setFromAxisAngle(new Vector3(1, 0, 0), Math.PI / 2);
 
@@ -83,17 +82,16 @@
 	<span class="text-right">{upright(latestReportedRotation) ? 'Up' : 'Down'}</span>
 </div>
 
-<!-- Flex horizontal center -->
-<div class="z-10 absolute top-2 right-2 variant-glass p-2 flex gap-2 place-items-center">
-	<i class="fa-solid fa-globe"></i>
-	<SlideToggle name="slide" bind:checked={useRocketModel}></SlideToggle>
-	<i class="fa-solid fa-rocket"></i>
-</div>
-
 <div class="z-10 absolute bottom-0 left-0 right-0 variant-glass h-12">
 	<Timeline></Timeline>
 </div>
 
-<div class="z-0 absolute w-full h-full">
-	<NavBall targetRotation={$targetRotation} bind:useRocketModel />
+<div class="absolute bg-black h-full w-full"></div>
+
+<div class="z-0 absolute inset-0">
+	<NavBall targetRotation={$targetRotation} />
+</div>
+
+<div class="z-0 absolute h-full w-full">
+	<HeadingCompass heading={$RocketCourse.data?.rocket_sensor_gps_vel[0]?.course ?? 0} />
 </div>

--- a/web/src/lib/components/Dashboard/RocketNavBall/types.ts
+++ b/web/src/lib/components/Dashboard/RocketNavBall/types.ts
@@ -16,6 +16,19 @@ export const RocketQuatDocument = graphql(`
 	}
 `);
 
+const RocketCourseDocument = graphql(`
+	subscription Course {
+		rocket_sensor_gps_vel(limit: 1, order_by: { time_stamp: desc }) {
+			course
+		}
+	}
+`);
+
+export const RocketCourse = subscriptionStore({
+	client: gqlClient,
+	query: RocketCourseDocument
+});
+
 export const RocketQuat = subscriptionStore({
 	client: gqlClient,
 	query: RocketQuatDocument


### PR DESCRIPTION
Closes #18 

Changes:
- Added a compass around the navball to indicate the heading
- Remove ability to switch between navball and rocket model as its going to be part of #112 
- Removed timeline from under navball as its going to be a core dashboard element

![image](https://github.com/uorocketry/rgs/assets/26195439/cdc3a291-64aa-442e-aadc-8f7b203d0197)

Known bugs:
- I explicitly overwrote light mode because I was a bit burned out from just making the base component. We can check if we are on dark mode by looking for a `.dark` class. This would be logged as another ticket or you can make a PR for the `navball-course` branch.