### PR TITLE
chore: update docker compose requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The frontends are the components that allow the user to interact with the infras
 
 There are a few things of interest that you might want to have running on your machine:
 
-- [Docker + Docker Compose](https://docs.docker.com/get-docker/)
-- The backend Database/Hasura instance which can be run with `docker-compose up`
+- [Docker](https://docs.docker.com/get-docker/) + [Docker Compose](https://docs.docker.com/compose/install/)
+- The backend Database/Hasura instance which can be run with `docker compose up`
 - The web frontend application. See its [README](web/README.md) for more information.
 - The `hydra_provider` project which can provide usefull serial/development-random-data for the web frontend. See its [README](hydra_provider/README.md) for more information.
 - Labjack Provider has not been implemented yet.

--- a/db/README.md
+++ b/db/README.md
@@ -50,4 +50,4 @@ Also make sure to track the tables in the Data tab of the Hasura console.
 2. Click on the `Data` tab then `default`->`public` [here](http://localhost:4000/console/data/default/schema/public) and click `Track All` for both **Untracked tables or views** and **Untracked foreign-key relationships**
 3. Run `pnpm run dump_hasura` on the console.
 4. Commit the changes.
-5. You might also want to re-run `docker-compose` as `docker-compose up --build` to make sure the changes are persisted.
+5. You might also want to re-run `docker compose` as `docker compose up --build` to make sure the changes are persisted.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.1"
-
 services:
     db:
         image: timescale/timescaledb:latest-pg16

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -8,7 +8,7 @@ module.exports = {
         },
         {
             name: "db",
-            script: "docker-compose up",
+            script: "docker compose up",
             cwd: "./",
         },
     ],

--- a/scripts/requirements/5_docker_compose.sh
+++ b/scripts/requirements/5_docker_compose.sh
@@ -2,5 +2,5 @@
 
 DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
 mkdir -p $DOCKER_CONFIG/cli-plugins
-# curl -SL https://github.com/docker/compose/releases/download/v2.27.0/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+curl -SL https://github.com/docker/compose/releases/download/v2.27.0/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
 chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose

--- a/scripts/requirements/5_docker_compose.sh
+++ b/scripts/requirements/5_docker_compose.sh
@@ -1,0 +1,6 @@
+# bin/bash -i
+
+DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+mkdir -p $DOCKER_CONFIG/cli-plugins
+# curl -SL https://github.com/docker/compose/releases/download/v2.27.0/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose


### PR DESCRIPTION
The system packages for legacy `docker-compose` V1 are [deprecated](https://docs.docker.com/compose/migrate/)  

This PR updates some documentation regarding that and adds a script that automatically installs it on UNIX systems